### PR TITLE
fix dynamic size of help dialog

### DIFF
--- a/src/main/java/nl/tudelft/ti2806/pl1/gui/HelpDialog.java
+++ b/src/main/java/nl/tudelft/ti2806/pl1/gui/HelpDialog.java
@@ -31,12 +31,6 @@ public class HelpDialog extends JDialog {
 	/** The size of the help dialog. */
 	private static final int WIDTH = 600, HEIGHT = 500;
 
-	/** The width difference between the dialog and its components. */
-	private static final int I_OFFSET = 50;
-
-	/** The size of the content label. */
-	private static final int I_WIDTH = WIDTH - I_OFFSET, I_HEIGHT = 620;
-
 	/** The padding around the labels. */
 	private static final Border EMPTY_BORDER = new EmptyBorder(10, 10, 10, 10);
 
@@ -72,13 +66,15 @@ public class HelpDialog extends JDialog {
 	 */
 	private JPanel makeUsingDNApp() {
 		JPanel ret = new JPanel(new BorderLayout());
+
 		JLabel info = new JLabel();
-		info.setText(readHelpFile(HELP_USING_DNAPP));
+		String help = readHelpFile(HELP_USING_DNAPP);
+		info.setText(help);
+		pack();
 		info.setBorder(EMPTY_BORDER);
-		info.setPreferredSize(new Dimension(I_WIDTH, I_HEIGHT));
 		JScrollPane jsp = new JScrollPane(info,
 				JScrollPane.VERTICAL_SCROLLBAR_AS_NEEDED,
-				JScrollPane.HORIZONTAL_SCROLLBAR_NEVER);
+				JScrollPane.HORIZONTAL_SCROLLBAR_AS_NEEDED);
 		ret.add(jsp, BorderLayout.CENTER);
 		return ret;
 	}

--- a/src/main/java/nl/tudelft/ti2806/pl1/gui/HelpDialog.java
+++ b/src/main/java/nl/tudelft/ti2806/pl1/gui/HelpDialog.java
@@ -53,6 +53,7 @@ public class HelpDialog extends JDialog {
 		Dimension size = new Dimension(WIDTH, HEIGHT);
 		setMinimumSize(size);
 		setResizable(false);
+		setLocationRelativeTo(null);
 		content = new JPanel(new BorderLayout());
 		tabs = new JTabbedPane();
 		tabs.addTab("Using DN/App", makeUsingDNApp());

--- a/src/main/resources/usingDNApp.help
+++ b/src/main/resources/usingDNApp.help
@@ -1,4 +1,5 @@
 <html>
+<body style='width: 420px'>
 <b>Setup:</b><br>
 To load a sequence graph, click on <i>Import graph</i> in the <i>File</i> menu. You will first get so select a <code>.node.graph</code> file and after that a new file chooser dialog will able you to open a <code>.edge.graph</code> file. After confirming the second file chooser dialog the sequence graph will be parsed. If the input files have wrong encoding, the importing will stop and an error message will be shown in the status bar.<br>
 <br>
@@ -26,4 +27,5 @@ Nodes which represent a collection of original nodes are highlighed purple.<br>
 If a phylogenetic tree has been loaded, it will be shown in the <i>Phylogenetic tree</i> tab.<br>
 You can select sets of genomes by left clicking on nodes in the tree. Clicking inner nodes will select or deselect the entire subtree below it.<br>
 By right clicking inner nodes in the tree, you can of the phylogenetic tree can be collapsed by right clicking on a branch inside the tree.
+</body>
 </html>


### PR DESCRIPTION
The entire content of the help dialog should be visible (with scrolling) and the width should be fixed, causing automatic line breaks.